### PR TITLE
mapfix: bhop_itaek submitted by fodback

### DIFF
--- a/mapfixes_bhop.txt
+++ b/mapfixes_bhop.txt
@@ -42,6 +42,10 @@ submitted fixes (no wipe):
 12687188945 - Reddish - added supermushroom8 to creatorname 
 10298870923 - Hello - added Justyn1 to creatorname 
 10350059091 - I Don't Know - added coolcoolzombiedude to creatorname 
+18841177635 - Itaek - fix by fodback
+• removed the temporary platform renaming;
+• each water part has a script inside it that does terrain;
+• lighting script fixups
 
 add map data:
 


### PR DESCRIPTION
Original fix description:
• removed the temporary platform renaming (i've made that to keep some stuff organized while i tested on studio, but completely forgot to remove 😅);
• for some reason - maybe me being dumb idk -, iterating through the folder and using each part as the parent for the terrain wasn't working for the water one, but it is for the rock and the grass, so i let the way it's working: each water part has a script inside it that does that;
• and some redundant things on the lighting script, like assiging the skybox texture, star count, etc on the sky object, but also on the script