### PR TITLE
autofill

### DIFF
--- a/pending_time_wipes.csv
+++ b/pending_time_wipes.csv
@@ -19,6 +19,6 @@ https://maps.strafes.net/mapfixes/80, 78486780449372, 3V3R51NC3, SURF, MAIN, FAS
 https://maps.strafes.net/mapfixes/210, 5692093974, Zor, SURF, MAIN, FASTE, Dec 20 2025 4:39:54 PM, BEFORE 1766252386, Fixed Faste oob - Wipe Faste [#1-300+
 https://maps.strafes.net/mapfixes/226, 5692153067, Saisei, SURF, MAIN, FASTE, Dec 28 2025 1:37:24 AM, BEFORE 1766889435, Fixed Faste oob prevention from new oobs resized end zone (doesn't affect times)
 https://maps.strafes.net/mapfixes/204, 6111024993, Palm Tree Vibes, SURF, MAIN, FASTE, Dec 28 2025 1:36:59 AM, BEFORE 1766889410, Fixed Faste oob - Wipe Faste [#1-300+(?)]
-UNSPECIFIED, 5692135173, Chimera, FLYTRIALS, MAIN, ALL, UNSPECIFIED, BEFORE 1731967560, fixed faste oob
+UNSPECIFIED, 5692135173, Chimera, FLYTRIALS, MAIN, ALL, Nov 18 2024 at 10:06:00 PM, BEFORE 1731967560, fixed faste oob
 https://maps.strafes.net/mapfixes/297, 5692152218, AcidicHopping, BHOP, MAIN, AUTOHOP, Mar 29 2026 5:24:58 AM, BEFORE 1774758286, Removes massive velocity on the humanoid at the start of the map similar to the 
-UNSPECIFIED, 13548537131, Hi Everyone, SURF, BONUS 1, FASTE, UNSPECIFIED, BEFORE 1739184600, changed b1 at some point plus new skip. needs full wipe
+UNSPECIFIED, 13548537131, Hi Everyone, SURF, BONUS 1, FASTE, Feb 10 2025 at 10:50:00 AM, BEFORE 1739184600, changed b1 at some point plus new skip. needs full wipe

--- a/pending_time_wipes.csv
+++ b/pending_time_wipes.csv
@@ -1,24 +1,24 @@
 Mapfix ID, MapID, Map Name, GameIDs, ModeIDs, StyleIDs, Date, Unix Constraint, Fix Description
-https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, FASTE, Dec 10 2025 2:20:29 AM, BEFORE 1765336829, fixed faste oob and s2 trigger skip
-https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, SIDEWAYS, Dec 10 2025 2:20:29 AM, BEFORE 1765336829, fixed faste oob and s2 trigger skip
-https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, HALFSIDEWAYS, Dec 10 2025 2:20:29 AM, BEFORE 1765336829, fixed faste oob and s2 trigger skip
-https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, AONLY, Dec 10 2025 2:20:29 AM, BEFORE 1765336829, fixed faste oob and s2 trigger skip
-https://maps.strafes.net/mapfixes/202, 5692169817, Stones, SURF, MAIN, FASTE, Dec 17 2025 4:42:00 AM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/197, 5692103566, Medieval, SURF, MAIN, FASTE, Dec 17 2025 4:42:20 AM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/185, 5692159660, Aztec, SURF, MAIN, FASTE, Dec 16 2025 6:21:22 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/183, 5692123834, Hole In One, SURF, MAIN, FASTE, Dec 16 2025 6:22:15 PM, UNSPECIFIED, fixed oob
-https://maps.strafes.net/mapfixes/188, 6111006827, Devolution, SURF, MAIN, FASTE, Dec 16 2025 6:21:34 PM, UNSPECIFIED, fixed faste oob on stage 2
-https://maps.strafes.net/mapfixes/187, 6111035047, Vivid Hard, SURF, MAIN, FASTE, Dec 17 2025 4:18:10 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/186, 5692128997, Vivid, SURF, MAIN, FASTE, Dec 16 2025 7:21:51 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/200, 5692112488, Pringles, SURF, MAIN, FASTE, Dec 17 2025 3:28:23 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/199, 5692186250, Not Far, SURF, MAIN, FASTE, Dec 17 2025 4:42:10 AM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/189, 5692094760, Disparity, SURF, MAIN, FASTE, Dec 17 2025 4:42:41 AM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/191, 6111012654, Gondal, SURF, MAIN, FASTE, Dec 17 2025 8:58:41 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/201, 6111033250, Sandy Sunset, SURF, MAIN, FASTE, Dec 17 2025 8:58:47 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/80, 78486780449372, 3V3R51NC3, SURF, MAIN, FASTE, Dec 21 2025 10:00:41 PM, UNSPECIFIED, fixed cheese
-https://maps.strafes.net/mapfixes/210, 5692093974, Zor, SURF, MAIN, FASTE, Dec 20 2025 4:39:54 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/226, 5692153067, Saisei, SURF, MAIN, FASTE, Dec 28 2025 1:37:24 AM, UNSPECIFIED, fixed faste oob and prevented new oobs
-https://maps.strafes.net/mapfixes/204, 6111024993, Palm Tree Vibes, SURF, MAIN, FASTE, Dec 28 2025 1:36:59 AM, UNSPECIFIED, fixed faste oob
-UNSPECIFIED, 5692135173, Chimera, FLYTRIALS, MAIN, ALL, Nov 18 2024 10:06:00 PM, UNSPECIFIED, fixed faste oob
-https://maps.strafes.net/mapfixes/297, 5692152218, AcidicHopping, BHOP, MAIN, AUTOHOP, Mar 29 2026 5:24:58 AM, UNSPECIFIED, fixed boosting off of player model at start
-UNSPECIFIED, 13548537131, Hi Everyone, SURF, BONUS 1, FASTE, UNSPECIFIED, UNSPECIFIED, changed b1 at some point plus new skip. needs full wipe
+https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, FASTE, Dec 10 2025 2:20:29 AM, BEFORE 1765336801, Fixed Faste oob added clips and triggers to prevent skips for b1 and fixed a Tri
+https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, SIDEWAYS, Dec 10 2025 2:20:29 AM, BEFORE 1765336801, Fixed Faste oob added clips and triggers to prevent skips for b1 and fixed a Tri
+https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, HALFSIDEWAYS, Dec 10 2025 2:20:29 AM, BEFORE 1765336801, Fixed Faste oob added clips and triggers to prevent skips for b1 and fixed a Tri
+https://maps.strafes.net/mapfixes/179, 5692153475, Yes, SURF, MAIN, AONLY, Dec 10 2025 2:20:29 AM, BEFORE 1765336801, Fixed Faste oob added clips and triggers to prevent skips for b1 and fixed a Tri
+https://maps.strafes.net/mapfixes/202, 5692169817, Stones, SURF, MAIN, FASTE, Dec 17 2025 4:42:00 AM, BEFORE 1765950111, Fixed Faste oob - Wipe Autohop [#1-21] Sideways [#1-4] Half-Sideways [#1-3] W-On
+https://maps.strafes.net/mapfixes/197, 5692103566, Medieval, SURF, MAIN, FASTE, Dec 17 2025 4:42:20 AM, BEFORE 1765950131, Fixed Faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/185, 5692159660, Aztec, SURF, MAIN, FASTE, Dec 16 2025 6:21:22 PM, BEFORE 1765912875, Fixed faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/183, 5692123834, Hole In One, SURF, MAIN, FASTE, Dec 16 2025 6:22:15 PM, BEFORE 1765912926, Fixed oob. Wipe Autohop [#1-11] Half-Sideways [#1-2] Faste [#1-300+]
+https://maps.strafes.net/mapfixes/188, 6111006827, Devolution, SURF, MAIN, FASTE, Dec 16 2025 6:21:34 PM, BEFORE 1765912885, Fixed a Faste found oob on Stage 2
+https://maps.strafes.net/mapfixes/187, 6111035047, Vivid Hard, SURF, MAIN, FASTE, Dec 17 2025 4:18:10 PM, BEFORE 1765991884, Fixed oob and 2nd ramp hitbox on Stage 6 - Wipe Faste [#1-300+] A-Only [#1-5]
+https://maps.strafes.net/mapfixes/186, 5692128997, Vivid, SURF, MAIN, FASTE, Dec 16 2025 7:21:51 PM, BEFORE 1765912896, Fixed Faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/200, 5692112488, Pringles, SURF, MAIN, FASTE, Dec 17 2025 3:28:23 PM, BEFORE 1765988890, Fixed Faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/199, 5692186250, Not Far, SURF, MAIN, FASTE, Dec 17 2025 4:42:10 AM, BEFORE 1765950121, Fixed Faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/189, 5692094760, Disparity, SURF, MAIN, FASTE, Dec 17 2025 4:42:41 AM, BEFORE 1765950154, Fixed Faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/191, 6111012654, Gondal, SURF, MAIN, FASTE, Dec 17 2025 8:58:41 PM, BEFORE 1766008676, Fixed Faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/201, 6111033250, Sandy Sunset, SURF, MAIN, FASTE, Dec 17 2025 8:58:47 PM, BEFORE 1766008715, Fixed Faste oob - Wipe Faste [#1-300+]
+https://maps.strafes.net/mapfixes/80, 78486780449372, 3V3R51NC3, SURF, MAIN, FASTE, Dec 21 2025 10:00:41 PM, BEFORE 1766358033, Last fix. Buttons in main reset when you respawn. Buttons in b1 prevent cheese. 
+https://maps.strafes.net/mapfixes/210, 5692093974, Zor, SURF, MAIN, FASTE, Dec 20 2025 4:39:54 PM, BEFORE 1766252386, Fixed Faste oob - Wipe Faste [#1-300+
+https://maps.strafes.net/mapfixes/226, 5692153067, Saisei, SURF, MAIN, FASTE, Dec 28 2025 1:37:24 AM, BEFORE 1766889435, Fixed Faste oob prevention from new oobs resized end zone (doesn't affect times)
+https://maps.strafes.net/mapfixes/204, 6111024993, Palm Tree Vibes, SURF, MAIN, FASTE, Dec 28 2025 1:36:59 AM, BEFORE 1766889410, Fixed Faste oob - Wipe Faste [#1-300+(?)]
+UNSPECIFIED, 5692135173, Chimera, FLYTRIALS, MAIN, ALL, UNSPECIFIED, BEFORE 1731967560, fixed faste oob
+https://maps.strafes.net/mapfixes/297, 5692152218, AcidicHopping, BHOP, MAIN, AUTOHOP, Mar 29 2026 5:24:58 AM, BEFORE 1774758286, Removes massive velocity on the humanoid at the start of the map similar to the 
+UNSPECIFIED, 13548537131, Hi Everyone, SURF, BONUS 1, FASTE, UNSPECIFIED, BEFORE 1739184600, changed b1 at some point plus new skip. needs full wipe


### PR DESCRIPTION
Autofill dates from mapfixes.

Errors during autofill:
```
Chimera Mapfix is >24h away (35941469 seconds) from date specified, not correcting fields
```

This error means that the autofill script found a mapfix for Chimera, but determined it is not relevant due to the date.